### PR TITLE
Fix serialization / deserialization of collection attribute values

### DIFF
--- a/src/datomic_type_extensions/api.clj
+++ b/src/datomic_type_extensions/api.clj
@@ -18,13 +18,15 @@
        form))
    tx))
 
+(defn query-attr-types [db]
+  (->> (for [attr (->> (d/q '[:find [?e ...] :where [?e :dte/valueType]] db)
+                       (map #(d/entity db %)))]
+         [(:db/ident attr) (select-keys attr #{:db/cardinality :dte/valueType})])
+       (into {})))
+
 (defn find-attr-types [db]
   (or (::attr-types db)
-      (into {} (d/q '[:find ?ident ?type
-                      :where
-                      [?e :dte/valueType ?type]
-                      [?e :db/ident ?ident]]
-                    db))))
+      (query-attr-types db)))
 
 (defn init! [conn]
   (when-not (d/entity (d/db conn) :dte/valueType)

--- a/src/datomic_type_extensions/core.clj
+++ b/src/datomic_type_extensions/core.clj
@@ -10,7 +10,8 @@
                            (set? val) (set (map f val))
                            (list? val) (map f val)
                            (vector? val) (mapv f val)
-                           :else (f val))))
+                           :else (throw (ex-info "Value must be either set, list or vector"
+                                                 {:attr-info attr-info :val val})))))
 
 (defn serialize-assertion-tx [form attr-infos]
   (if-let [[op e a v] (and (vector? form) form)]

--- a/src/datomic_type_extensions/entity.clj
+++ b/src/datomic_type_extensions/entity.clj
@@ -16,8 +16,10 @@
 
 (defn deserialize-attr [entity attr-types attr]
   (when-let [val (attr entity)]
-    (when-let [type (get attr-types attr)]
-      (core/apply-to-value (partial types/deserialize type) val))))
+    (when-let [attr-type (get attr-types attr)]
+      (core/apply-to-value (partial types/deserialize (:dte/valueType attr-type))
+                           attr-type
+                           val))))
 
 (deftype TypeExtendedEntityMap [^EntityMap entity attr-types touched?]
   Object

--- a/src/datomic_type_extensions/query.clj
+++ b/src/datomic_type_extensions/query.clj
@@ -12,8 +12,8 @@
 (defn find-var->type-mapping [query attr-types]
   (let [where-clauses (next (drop-while #(not= :where %) query))]
     (->> (keep find-binding where-clauses)
-         (keep (fn [[v a]] (when-let [type (attr-types a)]
-                             [v type])))
+         (keep (fn [[v a]] (when-let [attr-type (attr-types a)]
+                             [v (:dte/valueType attr-type)])))
          (into {}))))
 
 (defn deserialization-pattern [query attr-types]

--- a/src/datomic_type_extensions/query.clj
+++ b/src/datomic_type_extensions/query.clj
@@ -9,16 +9,16 @@
     (and (seq? e) (= 'get-else (first e)))
     [a (nth e 3)]))
 
-(defn find-var->type-mapping [query attr-types]
+(defn find-var->type-mapping [query attr-infos]
   (let [where-clauses (next (drop-while #(not= :where %) query))]
     (->> (keep find-binding where-clauses)
-         (keep (fn [[v a]] (when-let [attr-type (attr-types a)]
-                             [v (:dte/valueType attr-type)])))
+         (keep (fn [[v a]] (when-let [attr-info (attr-infos a)]
+                             [v (:dte/valueType attr-info)])))
          (into {}))))
 
-(defn deserialization-pattern [query attr-types]
+(defn deserialization-pattern [query attr-infos]
   (let [find-clauses (next (take-while #(not (#{:in :where} %)) query))
-        var->type (find-var->type-mapping query attr-types)
+        var->type (find-var->type-mapping query attr-infos)
         find-pattern #(if (and (seq? %) (= 'pull (first %)))
                         {:type :deserializable-form}
                         (var->type %))]
@@ -35,22 +35,22 @@
        :pattern {:type :tuple
                  :entries (mapv find-pattern find-clauses)}})))
 
-(defn deserialize-by-pattern [form pattern attr-types]
+(defn deserialize-by-pattern [form pattern attr-infos]
   (cond
     (keyword? pattern)
     (types/deserialize pattern form)
 
     (= (:type pattern) :vector)
-    (mapv #(deserialize-by-pattern % (:pattern pattern) attr-types) form)
+    (mapv #(deserialize-by-pattern % (:pattern pattern) attr-infos) form)
 
     (= (:type pattern) :tuple)
-    (mapv #(deserialize-by-pattern %1 %2 attr-types) form (:entries pattern))
+    (mapv #(deserialize-by-pattern %1 %2 attr-infos) form (:entries pattern))
 
     (= (:type pattern) :set)
-    (set (map #(deserialize-by-pattern % (:pattern pattern) attr-types) form))
+    (set (map #(deserialize-by-pattern % (:pattern pattern) attr-infos) form))
 
     (= (:type pattern) :deserializable-form)
-    (core/deserialize attr-types form)
+    (core/deserialize attr-infos form)
 
     :else form))
 

--- a/test/datomic_type_extensions/api_test.clj
+++ b/test/datomic_type_extensions/api_test.clj
@@ -158,13 +158,13 @@
          deref)
     conn))
 
-(deftest find-attr-infos
+(deftest find-attr->attr-info
   (is (= {:user/created-at (attr-info :java.time/instant)
           :user/updated-at (attr-info :java.time/instant)
           :user/demands (attr-info :keyword-backed-by-string :db.cardinality/many)
           :user/leaves-empty (attr-info :keyword-backed-by-string :db.cardinality/many)
           :client/id (attr-info :keyword-backed-by-string)}
-         (api/find-attr-infos (d/db (create-migrated-conn))))))
+         (api/find-attr->attr-info (d/db (create-migrated-conn))))))
 
 (deftest transact-async
   (is (= {:user/created-at #inst "2017-01-01T00:00:00"}

--- a/test/datomic_type_extensions/query_test.clj
+++ b/test/datomic_type_extensions/query_test.clj
@@ -2,10 +2,14 @@
   (:require [clojure.test :refer [deftest is testing]]
             [datomic-type-extensions.query :as sut]))
 
+(defn attr-type [value-type]
+  {:dte/valueType value-type
+   :db/cardinality :db.cardinality/one})
+
 (def attr-types
-  {:user/created-at :java.time/instant
-   :user/updated-at :java.time/instant
-   :client/id :keyword-backed-by-string})
+  {:user/created-at (attr-type :java.time/instant)
+   :user/updated-at (attr-type :java.time/instant)
+   :client/id (attr-type :keyword-backed-by-string)})
 
 (deftest deserialization-pattern
   (testing "a single value"

--- a/test/datomic_type_extensions/query_test.clj
+++ b/test/datomic_type_extensions/query_test.clj
@@ -2,14 +2,14 @@
   (:require [clojure.test :refer [deftest is testing]]
             [datomic-type-extensions.query :as sut]))
 
-(defn attr-type [value-type]
+(defn attr-info [value-type]
   {:dte/valueType value-type
    :db/cardinality :db.cardinality/one})
 
-(def attr-types
-  {:user/created-at (attr-type :java.time/instant)
-   :user/updated-at (attr-type :java.time/instant)
-   :client/id (attr-type :keyword-backed-by-string)})
+(def attr->attr-info
+  {:user/created-at (attr-info :java.time/instant)
+   :user/updated-at (attr-info :java.time/instant)
+   :client/id (attr-info :keyword-backed-by-string)})
 
 (deftest deserialization-pattern
   (testing "a single value"
@@ -17,24 +17,24 @@
       (is (= :java.time/instant
              (sut/deserialization-pattern
               '[:find ?v . :where [?e :user/created-at ?v]]
-              attr-types))))
+              attr->attr-info))))
 
     (testing "- not serialized"
       (is (nil? (sut/deserialization-pattern
                  '[:find ?v . :where [?e :user/name ?v]]
-                 attr-types))))
+                 attr->attr-info))))
 
     (testing "- entity id"
       (is (nil? (sut/deserialization-pattern
                  '[:find ?e . :where [?e :user/created-at ?v]]
-                 attr-types)))))
+                 attr->attr-info)))))
 
   (testing "vector"
     (is (= {:type :vector
             :pattern :java.time/instant}
            (sut/deserialization-pattern
             '[:find [?v ...] :where [?e :user/created-at ?v]]
-            attr-types))))
+            attr->attr-info))))
 
   (testing "sets of tuples"
     (is (= {:type :set
@@ -42,7 +42,7 @@
                       :entries [nil :java.time/instant]}}
            (sut/deserialization-pattern
             '[:find ?e ?v :where [?e :user/created-at ?v]]
-            attr-types))))
+            attr->attr-info))))
 
   (testing "pull syntax"
     (is (= {:type :vector
@@ -50,20 +50,20 @@
            (sut/deserialization-pattern
             '[:find [(pull ?e [:user/email :user/created-at]) ...]
               :where [?e :user/created-at ?v]]
-            attr-types)))
+            attr->attr-info)))
 
     (is (= {:type :deserializable-form}
            (sut/deserialization-pattern
             '[:find (pull ?e [:user/email :user/created-at]) .
               :where [?e :user/created-at ?v]]
-            attr-types)))
+            attr->attr-info)))
 
     (is (= {:type :set
             :pattern {:type :tuple
                       :entries [nil {:type :deserializable-form}]}}
            (sut/deserialization-pattern
             '[:find ?e (pull ?e [:user/email]) :where [?e :user/created-at ?v]]
-            attr-types)))))
+            attr->attr-info)))))
 
 (deftest deserialize-by-pattern
   (is (= :client-id
@@ -91,11 +91,11 @@
 (deftest find-var->type-mapping
   (is (= {'?v :java.time/instant}
          (sut/find-var->type-mapping '[:find ?v :where [_ :user/created-at ?v]]
-                                     attr-types)))
+                                     attr->attr-info)))
 
   (is (= {'?updated :java.time/instant}
          (sut/find-var->type-mapping '[:find ?email ?updated
                                        :in $
                                        :where [?e :user/email ?email]
                                        [(get-else $ ?e :user/updated-at nil) ?updated]]
-                                     attr-types))))
+                                     attr->attr-info))))


### PR DESCRIPTION
If an attribute value is a set or list, we're assuming the attribute has `:db/cardinality` set to `:db.cardinality/one`. This assumption is obviously flawed; the deserialized representation of an attribute value with might be a list or set (an example being serializing edn to string).

This PR fixes this by taking the attribute's cardinality into account when serializing / deserializing.