### PR TITLE
Wrap datomic.api/history to preserve attr-info

### DIFF
--- a/src/datomic_type_extensions/api.clj
+++ b/src/datomic_type_extensions/api.clj
@@ -71,6 +71,9 @@
 (defn filter [db pred]
   (assoc (d/filter db pred) ::attr->attr-info (find-attr->attr-info db)))
 
+(defn history [db]
+  (assoc (d/history db) ::attr->attr-info (find-attr->attr-info db)))
+
 (defn db [connection]
   (let [db (d/db connection)]
     (assoc db ::attr->attr-info (find-attr->attr-info db))))
@@ -112,7 +115,6 @@
               function
               gc-storage
               get-database-names
-              history
               ident
               index-range
               invoke


### PR DESCRIPTION
Avoids attempts by this lib to make entity lookup inadvertently when doing
otherwise totally legit history queries.