### PR TITLE
Expose init txs

### DIFF
--- a/src/datomic_type_extensions/api.clj
+++ b/src/datomic_type_extensions/api.clj
@@ -28,11 +28,14 @@
   (or (::attr->attr-info db)
       (query-attr->attr-info db)))
 
+(def init-txs
+  [{:db/ident :dte/valueType
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}])
+
 (defn init! [conn]
   (when-not (d/entity (d/db conn) :dte/valueType)
-    @(d/transact conn [{:db/ident :dte/valueType
-                        :db/valueType :db.type/keyword
-                        :db/cardinality :db.cardinality/one}])))
+    @(d/transact conn init-txs)))
 
 (defn prepare-tx-data [db tx-data]
   (->> tx-data


### PR DESCRIPTION
We need the ability to set the Datomic tx instant for testing purposes. This means we also need to control the tx instant the datomic-type-extension's "init transaction".

We propose to expose the "init transactions" as a var. This gives us the opportunity to initialize datomic-type-extension with our own modifications to the "init transaction".