### PR TITLE
Fix bug wrt serialization / deserialization symmetry

### DIFF
--- a/src/datomic_type_extensions/core.clj
+++ b/src/datomic_type_extensions/core.clj
@@ -1,5 +1,5 @@
 (ns datomic-type-extensions.core
-  (:require [clojure.walk :refer [postwalk]]
+  (:require [clojure.walk :refer [postwalk prewalk]]
             [datomic.api :as d]
             [datomic-type-extensions.types :as types]))
 
@@ -28,7 +28,7 @@
     form))
 
 (defn serialize-tx-data [attr->attr-info tx-data]
-  (postwalk
+  (prewalk
    (fn [form]
      (cond
        (map? form) (reduce #(update-attr types/serialize %1 %2) form attr->attr-info)


### PR DESCRIPTION
Both serialization and deserialization is implemented via `clojure.walk/postwalk`,
breaking serialization and deserialization symmetry when dealing with data with nested dte-backed attributes.

Case in point (from the added test):

```clj
(serialize-tx-data
  info
  {:user/edn {:user/created-at #time/inst "2017-01-01T00:00:00Z"}})
```

...renders:

`{:user/edn "{:user/created-at #inst \"2017-01-01T00:00:00.000-00:00\"}"}`

Fair enough, both `:user/created-at` and `:user/edn` have been serialized as
expected. Deserializing this though;

```clj
(deserialize
  info
  {:user/edn ":user/created-at #inst \"2017-01-01T00:00:00.000-00:00\"}"})
```

...renders:

`{:user/edn {:user/created-at #inst "2017-01-01T00:00:00.000-00:00"}}`

leaving `:user/created-at` as is and not deserialized.

This PR obviously breaks backwards compatibility. Fixing this bug by performing "multipass" deserialization instead might be a better approach wrt existing users, although we'll be still breaking compatibiliy.
