### PR TITLE
Add support for query-stats and io-stats in Datomic query

### DIFF
--- a/test/datomic_type_extensions/api_test.clj
+++ b/test/datomic_type_extensions/api_test.clj
@@ -362,6 +362,24 @@
                     [?e :user/created-at ?created-at]]
                   (d/db (create-populated-conn)))))))
 
+(deftest stats
+  (testing "Query stats returns map with result set in :ret"
+    (let [result (api/query
+                  {:query '[:find ?inst :where [_ :user/created-at ?inst]]
+                   :args [(d/db (create-populated-conn))]
+                   :query-stats true})]
+      (is (= #{[#time/inst "2017-01-01T00:00:00Z"]}
+             (:ret result)))
+      (is (some? (:query-stats result)))))
+  (testing "IO stats returns map with result set in :ret"
+    (let [result (api/query
+                  {:query '[:find ?inst :where [_ :user/created-at ?inst]]
+                   :args [(d/db (create-populated-conn))]
+                   :io-context :user/created-at})]
+      (is (= #{[#time/inst "2017-01-01T00:00:00Z"]}
+             (:ret result)))
+      (is (some? (:io-stats result))))))
+
 (comment
   (set! *print-namespace-maps* false)
 


### PR DESCRIPTION
If parameters to get query-stats or io-stats for a given context are added to the query map, the type conversions are run on the inner result set returned in `:ret`.