### PR TITLE
Show cached values on Entity print

### DIFF
--- a/src/datomic_type_extensions/entity.clj
+++ b/src/datomic_type_extensions/entity.clj
@@ -12,52 +12,47 @@
       false-or-truthy#
       (either ~@next))))
 
-(declare wrap equiv-entity)
+(declare wrap get-attr equiv-entity)
 
-(defn deserialize-attr [entity attr->attr-info attr]
-  (when-let [val (attr entity)]
-    (when-let [attr-info (get attr->attr-info attr)]
-      (core/apply-to-value (partial types/deserialize (:dte/valueType attr-info))
-                           attr-info
-                           val))))
+(defn deserialize-attr [attr->attr-info attr val]
+  (when-let [attr-info (and (some? val) (get attr->attr-info attr))]
+    (core/apply-to-value (partial types/deserialize (:dte/valueType attr-info))
+                         attr-info
+                         val)))
 
 (deftype TypeExtendedEntityMap [^EntityMap entity attr->attr-info touched?]
   Object
-  (hashCode [_]           (hash [(.hashCode entity) attr->attr-info]))
-  (equals [this o]        (and (instance? TypeExtendedEntityMap o)
-                               (equiv-entity this o)))
+  (hashCode [_]             (hash [(.hashCode entity) attr->attr-info]))
+  (equals [this o]          (and (instance? TypeExtendedEntityMap o)
+                                 (equiv-entity this o)))
 
   clojure.lang.Seqable
-  (seq [_]                (map (fn [[k v]]
-                                 (clojure.lang.MapEntry.
-                                  k
-                                  (either (deserialize-attr entity attr->attr-info k)
-                                          (wrap (.valAt entity k) attr->attr-info))))
-                               (.seq entity)))
+  (seq [this]               (map (fn [[k v]]
+                                   (clojure.lang.MapEntry.
+                                     k
+                                     (get-attr this k v)))
+                                 (.seq entity)))
 
   clojure.lang.Associative
-  (equiv [this o]         (and (instance? TypeExtendedEntityMap o)
-                               (equiv-entity this o)))
-  (containsKey [_ k]      (.containsKey entity k))
-  (entryAt [_ k]          (let [v (either (deserialize-attr entity attr->attr-info k)
-                                          (some-> entity (.entryAt k) .val (wrap attr->attr-info)))]
-                            (when (some? v) (first {k v}))))
-  (empty [_]              (wrap (.empty entity) attr->attr-info))
-  (count [_]              (.count entity))
+  (equiv [this o]           (and (instance? TypeExtendedEntityMap o)
+                                 (equiv-entity this o)))
+  (containsKey [_ k]        (.containsKey entity k))
+  (entryAt [this k]         (let [v (get-attr this k)]
+                              (when (some? v) (first {k v}))))
+  (empty [_]                (wrap (.empty entity) attr->attr-info))
+  (count [_]                (.count entity))
 
   clojure.lang.ILookup
-  (valAt [_ k]            (either (deserialize-attr entity attr->attr-info k)
-                                  (wrap (.valAt entity k) attr->attr-info)))
-  (valAt [_ k not-found]  (either (deserialize-attr entity attr->attr-info k)
-                                  (wrap (.valAt entity k not-found) attr->attr-info)))
+  (valAt [this k]           (get-attr this k))
+  (valAt [this k not-found] (get-attr this k not-found))
 
   datomic.Entity
-  (db [_]                 (assoc (.db entity) :datomic-type-extensions.api/attr->attr-info attr->attr-info))
-  (get [_ k]              (wrap (.get entity k) attr->attr-info))
-  (keySet [_]             (.keySet entity))
-  (touch [this]           (do (.touch entity)
-                              (reset! touched? true)
-                              this)))
+  (db [_]                   (assoc (.db entity) :datomic-type-extensions.api/attr->attr-info attr->attr-info))
+  (get [_ k]                (wrap (.get entity k) attr->attr-info))
+  (keySet [_]               (.keySet entity))
+  (touch [this]             (do (.touch entity)
+                                (reset! touched? true)
+                                this)))
 
 (defn- equiv-entity [^TypeExtendedEntityMap e1 ^TypeExtendedEntityMap e2]
   (.equiv (let [^EntityMap em (.entity e1)] em)
@@ -79,3 +74,14 @@
     (into (empty x) (map #(wrap % attr->attr-info) x))
 
     :else x))
+
+(defn get-attr*
+  [attr->attr-info attr val]
+  (either (deserialize-attr attr->attr-info attr val)
+          (wrap val attr->attr-info)))
+
+(defn get-attr
+  ([^TypeExtendedEntityMap entity attr]
+   (get-attr* (.-attr->attr-info entity) attr (.valAt (.-entity entity) attr)))
+  ([^TypeExtendedEntityMap entity attr not-found]
+   (get-attr* (.-attr->attr-info entity) attr (.valAt (.-entity entity) attr not-found))))

--- a/src/datomic_type_extensions/entity.clj
+++ b/src/datomic_type_extensions/entity.clj
@@ -20,7 +20,7 @@
                          attr-info
                          val)))
 
-(deftype TypeExtendedEntityMap [^EntityMap entity attr->attr-info touched?]
+(deftype TypeExtendedEntityMap [^EntityMap entity attr->attr-info]
   Object
   (hashCode [_]             (hash [(.hashCode entity) attr->attr-info]))
   (equals [this o]          (and (instance? TypeExtendedEntityMap o)
@@ -51,7 +51,6 @@
   (get [this k]             (get-attr this k))
   (keySet [_]               (.keySet entity))
   (touch [this]             (do (.touch entity)
-                                (reset! touched? true)
                                 this)))
 
 (defn- equiv-entity [^TypeExtendedEntityMap e1 ^TypeExtendedEntityMap e2]
@@ -59,26 +58,30 @@
           (let [^EntityMap em (.entity e2)] em)))
 
 (defmethod print-method TypeExtendedEntityMap [entity writer]
-  (print-method (merge {:db/id (:db/id entity)}
-                       (when @(.-touched? entity)
-                         (into {} entity)))
+  (print-method (wrap (.cache (.-entity entity)) (.-attr->attr-info entity))
                 writer))
-
-(defn wrap
-  [x attr->attr-info]
-  (cond
-    (instance? datomic.Entity x)
-    (TypeExtendedEntityMap. x attr->attr-info (atom false))
-
-    (coll? x)
-    (into (empty x) (map #(wrap % attr->attr-info) x))
-
-    :else x))
 
 (defn get-attr*
   [attr->attr-info attr val]
   (either (deserialize-attr attr->attr-info attr val)
           (wrap val attr->attr-info)))
+
+(defn wrap
+  [x attr->attr-info]
+  (cond
+    (instance? datomic.Entity x)
+    (TypeExtendedEntityMap. x attr->attr-info)
+
+    (map-entry? x)
+    (let [[k v] x]
+      (clojure.lang.MapEntry.
+        k
+        (get-attr* attr->attr-info k v)))
+
+    (coll? x)
+    (into (empty x) (map #(wrap % attr->attr-info) x))
+
+    :else x))
 
 (defn get-attr
   ([^TypeExtendedEntityMap entity attr]

--- a/src/datomic_type_extensions/entity.clj
+++ b/src/datomic_type_extensions/entity.clj
@@ -48,7 +48,7 @@
 
   datomic.Entity
   (db [_]                   (assoc (.db entity) :datomic-type-extensions.api/attr->attr-info attr->attr-info))
-  (get [_ k]                (wrap (.get entity k) attr->attr-info))
+  (get [this k]             (get-attr this k))
   (keySet [_]               (.keySet entity))
   (touch [this]             (do (.touch entity)
                                 (reset! touched? true)

--- a/test/datomic_type_extensions/api_test.clj
+++ b/test/datomic_type_extensions/api_test.clj
@@ -206,7 +206,7 @@
   (let [wrapped-entity (api/entity (d/db (create-populated-conn))
                                    [:user/email "foo@example.com"])]
     (testing "deserializes registered attributes"
-      (is (= #time/inst "2017-01-01T00:00:00Z" (:user/created-at wrapped-entity)))
+      (is (= #time/inst "2017-01-01T00:00:00Z" (:user/created-at wrapped-entity) (.get wrapped-entity :user/created-at)))
       (is (= #{:peace :love :happiness} (:user/demands wrapped-entity))))
 
     (testing "leaves unregistered attributes alone"

--- a/test/datomic_type_extensions/api_test.clj
+++ b/test/datomic_type_extensions/api_test.clj
@@ -163,7 +163,18 @@
     :db/cardinality :db.cardinality/many}
    {:db/ident :client/admin
     :db/valueType :db.type/ref
-    :db/cardinality :db.cardinality/one}])
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :person/id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+   {:db/ident       :person/children
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true}
+   {:db/ident       :person/friends
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/many}])
 
 (defn create-migrated-conn []
   (let [conn (create-conn)]
@@ -199,7 +210,12 @@
         :client/users [{:user/email "foo@example.com"
                         :user/created-at #time/inst "2017-01-01T00:00:00Z"
                         :user/demands [:peace :love :happiness]
-                        :user/favorite-foods [:pizza :lasagna :haggis]}]}])
+                        :user/favorite-foods [:pizza :lasagna :haggis]}]}
+       {:person/id "parent1"
+        :person/children [{:person/id "child1"}
+                          {:person/id "child2"}
+                          {:person/id "child3"}]
+        :person/friends [{:person/id "sibling1"}]}])
     conn))
 
 (deftest entity
@@ -256,18 +272,21 @@
 
     (testing "printing"
       (testing "defaults to only show :db/id"
-        (is (= (let [client-db-id (:db/id datomic-entity)]
-                 {:db/id client-db-id})
-               (edn/read-string (pr-str wrapped-entity)))))
+        (let [client-db-id (:db/id datomic-entity)
+              untouched-entity (api/entity db [:client/id :the-client])]
+          (is (= {:db/id client-db-id}
+                 (edn/read-string (pr-str untouched-entity))))))
 
       (testing "shows all attributes when entity has been touched"
-        (is (= (let [client-db-id (:db/id datomic-entity)
-                     user-db-id (:db/id (first (:client/users datomic-entity)))]
-                 {:client/id :the-client
-                  :client/users #{{:db/id user-db-id}}
-                  :db/id client-db-id})
-               (edn/read-string {:readers *data-readers*}
-                                (pr-str (d/touch wrapped-entity))))))
+        (is (= #{:db/id :client/users :client/id}
+               (set (keys (edn/read-string {:readers *data-readers*}
+                                           (pr-str (d/touch wrapped-entity))))))))
+
+      (testing "shows the same values as datomic entity when touched"
+        (let [datomic-entity (datomic.api/entity (d/db (create-populated-conn)) [:person/id "parent1"])
+              wrapped-entity (api/entity (d/db (create-populated-conn)) [:person/id "parent1"])]
+          (is (= (edn/read-string (pr-str (d/touch datomic-entity)))
+                 (edn/read-string (pr-str (d/touch wrapped-entity)))))))
 
       (testing "shows deserialized value of type extended attributes"
         (is (= {:db/id (:db/id (first (:client/users datomic-entity)))


### PR DESCRIPTION
This solves #13. 

It depends on the fix in https://github.com/magnars/datomic-type-extensions/pull/18.

Turns out the bug wasn't in how entities were touched, but in how they were printed. Print should show all the values in the entity's cache, this includes values added to the cache by other means than a touch (like a regular lookup). 

I refactored the get and deserialize code, and discovered that the implementation of `.get` for `datomic.Entity` actually didn't deserialize the value, so I fixed that as well. 